### PR TITLE
Add TcpEstablished override dump/restore

### DIFF
--- a/task.proto
+++ b/task.proto
@@ -95,6 +95,7 @@ message DumpArgs {
   CRType Type = 3;
   string JID = 4;
   bool GPU = 5;
+  bool TcpEstablished = 6;
 }
 
 message DumpResp {
@@ -113,6 +114,7 @@ message RestoreArgs {
   uint32 UID = 5;
   uint32 GID = 6;
   repeated uint32 Groups = 7;
+  bool TcpEstablished = 8;
 }
 
 message RestoreResp {


### PR DESCRIPTION
In some cases, the auto detection of the `--tcp-established` flag does not work. It would be useful to add an override through CLI.