### PR TITLE
Remove go_packages 

### DIFF
--- a/gpu.proto
+++ b/gpu.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package cedanagpu;
 
-option go_package = "github.com/cedana/cedana/api/services/gpu";
-
 service CedanaGPU {
   rpc Checkpoint(CheckpointRequest) returns (CheckpointResponse) {};
   rpc Restore(RestoreRequest) returns (RestoreResponse) {};

--- a/task.proto
+++ b/task.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 import "gpu.proto";
 package cedana.services.task;
 
-option go_package = "github.com/cedana/cedana/api/services/task";
-
 // Query functions here work just like your familiar query functions in HTTP GET requests,
 // where if you don't specify anything in the query, it will return all the valid results,
 // but if you do it will filter out based on the query parameters.


### PR DESCRIPTION
Having an issue with relative vs non-relative proto paths. This should clean things up across cedana and cedana-market.