### PR TITLE
Add method to retrieve daemon config

### DIFF
--- a/task.proto
+++ b/task.proto
@@ -473,5 +473,5 @@ message GetConfigRequest {
 }
 
 message GetConfigResponse {
-  string JSON = 1;
+  google.protobuf.Struct Config = 1;
 }

--- a/task.proto
+++ b/task.proto
@@ -38,6 +38,9 @@ service TaskService {
 
   // Health
   rpc DetailedHealthCheck(DetailedHealthCheckRequest) returns (DetailedHealthCheckResponse) {}
+
+  // Config
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
 }
 
 /////////////////////
@@ -460,4 +463,15 @@ message DetailedHealthCheckResponse {
 message HealthCheckStats {
    string criuVersion = 1;
    cedanagpu.HealthCheckResponse GPUHealthCheck = 2;
+}
+
+/////////////////////
+///////Config////////
+/////////////////////
+
+message GetConfigRequest {
+}
+
+message GetConfigResponse {
+  string JSON = 1;
 }

--- a/task.proto
+++ b/task.proto
@@ -473,5 +473,5 @@ message GetConfigRequest {
 }
 
 message GetConfigResponse {
-  google.protobuf.Struct Config = 1;
+  string JSON = 1;
 }


### PR DESCRIPTION
Currently, if running `cedana config show`, the config is attempted to be read directly. Instead, when this is called the config that the daemon is running under should be returned.