### PR TITLE
Add CRIU opts to runc restore

### DIFF
--- a/task.proto
+++ b/task.proto
@@ -308,6 +308,7 @@ message RuncRestoreArgs {
   RuncOpts Opts = 4;
   CRType Type = 5;
   string CheckpointID = 6;
+  CriuOpts CriuOpts = 7;
 }
 
 message RuncRestoreResp {

--- a/task.proto
+++ b/task.proto
@@ -304,11 +304,10 @@ message CriuOpts {
 message RuncRestoreArgs {
   string ContainerID = 1;
   string ImagePath = 2;
-  bool IsK3s = 3;
-  RuncOpts Opts = 4;
-  CRType Type = 5;
-  string CheckpointID = 6;
-  CriuOpts CriuOpts = 7;
+  RuncOpts Opts = 3;
+  CRType Type = 4;
+  string CheckpointID = 5;
+  CriuOpts CriuOpts = 6;
 }
 
 message RuncRestoreResp {


### PR DESCRIPTION
This allows us to pass CRIU options during runc restore as we already have them for dump. We can now add CLI flags as we like, such as `--file-locks`.
See this PR: https://github.com/cedana/cedana/pull/317

Also removes `isK3s` option, as it's no longer used.