### PR TITLE
update: add runtime root and sock as optional fields

### DIFF
--- a/task.proto
+++ b/task.proto
@@ -575,8 +575,8 @@ message QueueJobCheckpointRequest {
     string PodName = 3;
     string ImageName = 4;
     string Id = 5;
-    optional string runtime_root = 6;
-    optional string runtime_sock = 7;
+    optional string RuntimeRoot = 6;
+    optional string RuntimeSock = 7;
 }
 
 message QueueJobRestoreRequest {

--- a/task.proto
+++ b/task.proto
@@ -575,6 +575,8 @@ message QueueJobCheckpointRequest {
     string PodName = 3;
     string ImageName = 4;
     string Id = 5;
+    optional string runtime_root = 6;
+    optional string runtime_sock = 7;
 }
 
 message QueueJobRestoreRequest {


### PR DESCRIPTION
This is needed so that we provide the same options as normal CR apis for job queue as well.

Also makes testing easier for non-standard deployments.