### PR TITLE
refactor: asr metrics for more info

### DIFF
--- a/task.proto
+++ b/task.proto
@@ -615,15 +615,14 @@ message ContainerInfoRequest {
 
 message ContainerInfo {
   double CpuTime = 1;
-  double CpuLoadAvg = 2;
-  double MaxMemory = 3;
+  double FilesystemIoTime = 2;
+  double AcceleratorMemory = 3;
   double CurrentMemory = 4;
   double NetworkIO = 5;
   double DiskIO = 6;
   string ContainerName = 7;
-  string DaemonId = 8;
-  string Labels = 9;
-  string Image = 10;
+  string Labels = 8;
+  string Image = 9;
 }
 
 message ContainersInfo {

--- a/task.proto
+++ b/task.proto
@@ -621,8 +621,9 @@ message ContainerInfo {
   double NetworkIO = 5;
   double DiskIO = 6;
   string ContainerName = 7;
-  string Labels = 8;
-  string Image = 9;
+  string Processes = 8;
+  string Labels = 9;
+  string Image = 10;
 }
 
 message ContainersInfo {


### PR DESCRIPTION
Cadvisor can given right circumstances(many cases where it doesn't work eg, when using MIG, etc. but until we add metrics support to gpu-controller this is pretty good, and should also not need gpu-controller to be installed for now!) also fetch accelerator memory usage, aka GPU memory usage.

Filesystem IoTime fetches the operations with inodes spent within the request_queue before they are finished.

Also removes DaemonId we don't need it in the field we pass it along in the trace down the road once we have better reporting we should still not be fetching it within the request (it adds to the cpu time and space budget of network requests, note grpc is cpu heavy so it's better to use smaller payload sizes).

Note: BREAKING change, but should be fine as we only use the api in daemon so can't break any services.