### PR TITLE
[WIP] Add network-lock in task criuopt

### DIFF
--- a/task/task.proto
+++ b/task/task.proto
@@ -345,6 +345,7 @@ message CriuOpts {
   repeated string External = 18;
   bool TcpClose = 19;
   bool TcpSkipInFlight = 20;
+  string NetworkLock = 21;
 }
 
 message RuncRestoreArgs {


### PR DESCRIPTION
[CED-836](https://linear.app/cedana/issue/CED-836/add-network-lock-option-in-tcp-established)
Adds nftables/iptables criu flag option for network dumps.
Working on testing it locally.