### PR TITLE
Add timing for readHostMemory in GPURestoreStats

### DIFF
--- a/gpu/cedanagpu/gpu.proto
+++ b/gpu/cedanagpu/gpu.proto
@@ -54,9 +54,9 @@ message AvailableCUDAAPIs {
 }
 
 message GPURestoreStats {
-    int64 copyHostMemTime = 1;
-    int64 copyMemTime = 2;
-    int64 replayCallsTime = 3;
+    int64 copyMemTime = 1;
+    int64 replayCallsTime = 2;
+    int64 copyHostMemTime = 3;
 }
 
 message UnblockBarrierRequest {}

--- a/gpu/cedanagpu/gpu.proto
+++ b/gpu/cedanagpu/gpu.proto
@@ -54,8 +54,9 @@ message AvailableCUDAAPIs {
 }
 
 message GPURestoreStats {
-    int64 copyMemTime = 1;
-    int64 replayCallsTime = 2;
+    int64 copyHostMemTime = 1;
+    int64 copyMemTime = 2;
+    int64 replayCallsTime = 3;
 }
 
 message UnblockBarrierRequest {}


### PR DESCRIPTION
Support for new timer label `copyHostMemTime` field of `GPURestoreStats`, similar to `copyMemTime` and `replayCallsTime`. Duration `copyHostMemTime` should be << `copyMemTime` and `replayCallsTime`. 

Example output:
<img width="1296" alt="example" src="https://github.com/user-attachments/assets/c3a0fc27-8593-40d9-b5bb-e1ad7530e06a" />

Related PRs: [cedana daemon](https://github.com/cedana/cedana/pull/438), cedana-gpu