### PR TITLE
Add freeze, unfreeze to GPU

### DIFF
--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -9,7 +9,6 @@ service Controller {
   rpc Detach(DetachReq) returns (DetachResp) {}
 
   rpc Freeze(FreezeReq) returns (FreezeResp) {}
-  rpc Unfreeze(UnfreezeReq) returns (UnfreezeResp) {}
 
   rpc Dump(DumpReq) returns (DumpResp) {}
   rpc Restore(RestoreReq) returns (RestoreResp) {}
@@ -29,10 +28,6 @@ message DetachResp {}
 message FreezeReq {}
 
 message FreezeResp {}
-
-message UnfreezeReq {}
-
-message UnfreezeResp {}
 
 message DumpReq {
   string Dir = 1;

--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -28,7 +28,11 @@ message DetachResp {}
 
 message FreezeReq {}
 
+message FreezeResp {}
+
 message UnfreezeReq {}
+
+message UnfreezeResp {}
 
 message DumpReq {
   string Dir = 1;

--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -8,6 +8,9 @@ service Controller {
   rpc Attach(AttachReq) returns (AttachResp) {}
   rpc Detach(DetachReq) returns (DetachResp) {}
 
+  rpc Freeze(FreezeReq) returns (FreezeResp) {}
+  rpc Unfreeze(UnfreezeReq) returns (UnfreezeResp) {}
+
   rpc Dump(DumpReq) returns (DumpResp) {}
   rpc Restore(RestoreReq) returns (RestoreResp) {}
   rpc HealthCheck(HealthCheckReq) returns (HealthCheckResp) {}
@@ -23,16 +26,16 @@ message DetachReq {}
 
 message DetachResp {}
 
+message FreezeReq {}
+
+message UnfreezeReq {}
+
 message DumpReq {
   string Dir = 1;
   bool Stream = 2;
-  bool LeaveRunning = 3;
 }
 
-message DumpResp {
-  string MemPath = 1;
-  string CkptPath = 2;
-}
+message DumpResp {}
 
 message RestoreReq {
   string Dir = 1;


### PR DESCRIPTION
Changes required for enabling parallel GPU dump. Also removes the `LeaveRunning` flag as it's redundant, explained in the GPU PR.

cedana PR: https://github.com/cedana/cedana/pull/490
cedana-gpu PR: https://github.com/cedana/cedana-gpu/pull/114