### PR TITLE
Hoist UIDs, GIDs, Groups to RunReq

### DIFF
--- a/cedana/daemon/daemon.proto
+++ b/cedana/daemon/daemon.proto
@@ -164,8 +164,12 @@ message RunReq {
   bool Attachable = 5;
   RunAction Action = 6;
 
-  Details Details = 7;
-  repeated string Env = 8;
+  repeated uint32 UIDs = 7;
+  repeated uint32 GIDs = 8;
+  repeated uint32 Groups = 9;
+  repeated string Env = 10;
+
+  Details Details = 11;
 }
 
 message RunResp {

--- a/cedana/daemon/daemon.proto
+++ b/cedana/daemon/daemon.proto
@@ -164,8 +164,8 @@ message RunReq {
   bool Attachable = 5;
   RunAction Action = 6;
 
-  repeated uint32 UIDs = 7;
-  repeated uint32 GIDs = 8;
+  uint32 UID = 7;
+  uint32 GID = 8;
   repeated uint32 Groups = 9;
   repeated string Env = 10;
 

--- a/cedana/daemon/daemon.proto
+++ b/cedana/daemon/daemon.proto
@@ -99,8 +99,12 @@ message RestoreReq {
   string Log = 5; // standard IO log file
   bool Attachable = 6;
 
-  Details Details = 7;
-  repeated string Env = 8;
+  uint32 UID = 7;
+  uint32 GID = 8;
+  repeated uint32 Groups = 9;
+  repeated string Env = 10;
+
+  Details Details = 11;
 }
 
 message RestoreResp {

--- a/cedana/daemon/process.proto
+++ b/cedana/daemon/process.proto
@@ -11,9 +11,6 @@ message Process {
   string Path = 2;
   string WorkingDir = 3;
   repeated string Args = 4;
-  uint32 UID = 6;
-  uint32 GID = 7;
-  repeated uint32 Groups = 8;
 }
 
 message ProcessState {
@@ -30,9 +27,12 @@ message ProcessState {
 
   Host Host = 11;
 
-  uint32 SID = 12; // session ID
+  repeated uint32 UIDs = 12;
+  repeated uint32 GIDs = 13;
+  repeated uint32 Groups = 14;
+  uint32 SID = 15; // session ID
 
-  bool GPUEnabled = 13;
+  bool GPUEnabled = 16;
 }
 
 message File {

--- a/cedana/daemon/process.proto
+++ b/cedana/daemon/process.proto
@@ -30,12 +30,9 @@ message ProcessState {
 
   Host Host = 11;
 
-  repeated uint32 UIDs = 12;
-  repeated uint32 GIDs = 13;
-  repeated uint32 Groups = 14;
-  uint32 SID = 15; // session ID
+  uint32 SID = 12; // session ID
 
-  bool GPUEnabled = 16;
+  bool GPUEnabled = 13;
 }
 
 message File {


### PR DESCRIPTION
Hoists UIDs, GIDs, Groups to `RunReq` so that they can be used for all types of run requests, not just process. Also adds these to `RestoreReq` (required for GPU controller spawning).