### PR TITLE
CED-2123: CRIU restore profiling

### DIFF
--- a/criu/criu/criu.proto
+++ b/criu/criu/criu.proto
@@ -291,26 +291,15 @@ message restore_stats_entry {
 	optional uint64			pages_restored		= 5;
 	optional uint32			pre_restore_time	= 6;
 	optional uint32			post_restore_time	= 7;
-	optional uint32			namespaces_restore_time	= 8;
-	optional pid_restore_stats	per_pid_restore_stats	= 9;
+	repeated process_stats_entry	process_restore_stats	= 8;
 }
 
-message pid_restore_stats {
-	repeated pid_restore_stats_entry stats = 1;
+message process_stats_entry {
+	optional uint32		pid		= 1;
+	repeated time_entry	time_entries	= 2;
 }
 
-message pid_restore_stats_entry {
-	optional uint32 pid			= 1;
-	optional uint32 restore_resource_time	= 2;
-	optional uint32 pie_prepare_time	= 3;
-	optional uint32 restore_namespaces_time = 4;
-	optional uint32 pie_total_time		= 5;
-	optional uint32 pie_restore_mem_time	= 6;
-	optional uint32 pie_restore_thread_time = 7;
-	optional uint32 pie_post_restore_time	= 8;
-}
-
-message stats_entry {
-	optional dump_stats_entry	dump			= 1;
-	optional restore_stats_entry	restore			= 2;
+message time_entry {
+	optional string name = 1;
+	optional uint32 time = 2;
 }

--- a/criu/criu/criu.proto
+++ b/criu/criu/criu.proto
@@ -158,6 +158,7 @@ message criu_dump_resp {
 
 message criu_restore_resp {
   required int32 pid = 1;
+  optional restore_stats_entry stats	= 2;
 }
 
 message criu_notify {
@@ -256,4 +257,60 @@ message criu_version {
   optional int32 sublevel = 4;
   optional int32 extra = 5;
   optional string name = 6;
+}
+
+// This one contains statistics about dump/restore process
+message dump_stats_entry {
+	required uint32			freezing_time		= 1;
+	required uint32			frozen_time		= 2;
+	required uint32			memdump_time		= 3;
+	required uint32			memwrite_time		= 4;
+
+	required uint64			pages_scanned		= 5;
+	required uint64			pages_skipped_parent	= 6;
+	required uint64			pages_written		= 7;
+
+	optional uint32			irmap_resolve		= 8;
+
+	required uint64			pages_lazy		= 9;
+	optional uint64			page_pipes		= 10;
+	optional uint64			page_pipe_bufs		= 11;
+
+	optional uint64			shpages_scanned		= 12;
+	optional uint64			shpages_skipped_parent	= 13;
+	optional uint64			shpages_written		= 14;
+}
+
+message restore_stats_entry {
+	required uint64			pages_compared		= 1;
+	required uint64			pages_skipped_cow	= 2;
+
+	required uint32			forking_time		= 3;
+	required uint32			restore_time		= 4;
+
+	optional uint64			pages_restored		= 5;
+	optional uint32			pre_restore_time	= 6;
+	optional uint32			post_restore_time	= 7;
+	optional uint32			namespaces_restore_time	= 8;
+	optional pid_restore_stats	per_pid_restore_stats	= 9;
+}
+
+message pid_restore_stats {
+	repeated pid_restore_stats_entry stats = 1;
+}
+
+message pid_restore_stats_entry {
+	optional uint32 pid			= 1;
+	optional uint32 restore_resource_time	= 2;
+	optional uint32 pie_prepare_time	= 3;
+	optional uint32 restore_namespaces_time = 4;
+	optional uint32 pie_total_time		= 5;
+	optional uint32 pie_restore_mem_time	= 6;
+	optional uint32 pie_restore_thread_time = 7;
+	optional uint32 pie_post_restore_time	= 8;
+}
+
+message stats_entry {
+	optional dump_stats_entry	dump			= 1;
+	optional restore_stats_entry	restore			= 2;
 }

--- a/criu/criu/criu.proto
+++ b/criu/criu/criu.proto
@@ -259,28 +259,6 @@ message criu_version {
   optional string name = 6;
 }
 
-// This one contains statistics about dump/restore process
-message dump_stats_entry {
-	required uint32			freezing_time		= 1;
-	required uint32			frozen_time		= 2;
-	required uint32			memdump_time		= 3;
-	required uint32			memwrite_time		= 4;
-
-	required uint64			pages_scanned		= 5;
-	required uint64			pages_skipped_parent	= 6;
-	required uint64			pages_written		= 7;
-
-	optional uint32			irmap_resolve		= 8;
-
-	required uint64			pages_lazy		= 9;
-	optional uint64			page_pipes		= 10;
-	optional uint64			page_pipe_bufs		= 11;
-
-	optional uint64			shpages_scanned		= 12;
-	optional uint64			shpages_skipped_parent	= 13;
-	optional uint64			shpages_written		= 14;
-}
-
 message restore_stats_entry {
 	required uint64			pages_compared		= 1;
 	required uint64			pages_skipped_cow	= 2;


### PR DESCRIPTION
- Brings over the `restore_stats_entry` message from upstream CRIU but we add a new field to it called `process_restore_stats`
- Modify the rpc restore response to include `restore_stats_entry` 
- `process_restore_stats` is just the time each process took to do each CRIU restore "stage" (the `name` field in `struct time_entry` represents the stage)

Related:
- https://github.com/cedana/cedana/pull/815
- https://github.com/cedana/criu/pull/27