### PR TITLE
Feature/ced 2098 profile sections of the gpu checkpointrestore operations

### DIFF
--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -38,7 +38,9 @@ message DumpReq {
   bool LeaveRunning = 3;
 }
 
-message DumpResp {}
+message DumpResp {
+  GpuProfile Profile = 1;
+}
 
 message RestoreReq {
   string Dir = 1;
@@ -47,12 +49,51 @@ message RestoreReq {
 
 message RestoreResp {
   RestoreStats RestoreStats = 1;
+  GpuProfile Profile = 2;
 }
 
 message RestoreStats {
   int64 CopyMemTime = 1; // in milliseconds
   int64 ReplayCallsTime = 2; // in milliseconds
   int64 CopyHostMemTime = 3; // in milliseconds
+}
+
+message GpuProfile {
+  repeated WorkerProfile Workers = 1;
+  WorkerProfileSummary Summary = 2;
+}
+
+message WorkerProfile {
+  int32 WorkerIndex = 1;
+  uint32 PID = 2;
+  int64 DurationMs = 3;
+  uint64 Bytes = 4; // bytes written during dump, bytes read during restore
+  repeated WorkerPhaseProfile Phases = 5;
+}
+
+message WorkerPhaseProfile {
+  string Name = 1;
+  int64 DurationMs = 2;
+}
+
+message WorkerProfileSummary {
+  uint32 Count = 1;
+  int64 AverageDurationMs = 2;
+  int32 SlowestWorkerIndex = 3;
+  uint32 SlowestPID = 4;
+  int64 SlowestDurationMs = 5;
+  uint64 TotalBytes = 6; // bytes written during dump, bytes read during restore
+  repeated WorkerPhaseProfileSummary Phases = 7;
+}
+
+message WorkerPhaseProfileSummary {
+  string Name = 1;
+  uint32 Count = 2;
+  int64 AverageDurationMs = 3;
+  int32 SlowestWorkerIndex = 4;
+  uint32 SlowestPID = 5;
+  int64 SlowestDurationMs = 6;
+  int64 TotalDurationMs = 7;
 }
 
 message InfoReq {}

--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -69,6 +69,7 @@ message GpuFunctionProfile {
   int64 DurationMs = 2;
   uint32 Count = 3; // number of workers
   int64 TotalDurationMs = 4; // sum across all workers
+  uint64 Bytes = 5; // total bytes written during dump, bytes read during restore
 }
 
 message WorkerProfile {
@@ -82,6 +83,7 @@ message WorkerProfile {
 message WorkerPhaseProfile {
   string Name = 1;
   int64 DurationMs = 2;
+  uint64 Bytes = 3; // bytes written during dump, bytes read during restore
 }
 
 message WorkerProfileSummary {
@@ -102,6 +104,9 @@ message WorkerPhaseProfileSummary {
   uint32 SlowestPID = 5;
   int64 SlowestDurationMs = 6;
   int64 TotalDurationMs = 7;
+  uint64 TotalBytes = 8; // total bytes written during dump, bytes read during restore
+  uint64 AverageBytes = 9; // average bytes per worker
+  uint64 SlowestBytes = 10; // bytes for the slowest worker
 }
 
 message InfoReq {}

--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -61,6 +61,14 @@ message RestoreStats {
 message GpuProfile {
   repeated WorkerProfile Workers = 1;
   WorkerProfileSummary Summary = 2;
+  repeated GpuFunctionProfile Functions = 3;
+}
+
+message GpuFunctionProfile {
+  string Name = 1;
+  int64 DurationMs = 2;
+  uint32 Count = 3; // number of workers
+  int64 TotalDurationMs = 4; // sum across all workers
 }
 
 message WorkerProfile {


### PR DESCRIPTION
- Add GPU profiling data to the GPU controller API.
- Add `GpuProfile` to `DumpResp`.
- Add `GpuProfile` to `RestoreResp`.
- Add worker profiling messages:
  - `WorkerProfile`
  - `WorkerPhaseProfile`
  - `WorkerProfileSummary`
  - `WorkerPhaseProfileSummary`
- Add function profiling message:
  - `GpuFunctionProfile`
- Track:
  - per-worker duration
  - per-worker PID
  - per-worker bytes written/read
  - per-phase duration
  - per-phase bytes
  - worker count
  - average worker duration
  - slowest worker
  - phase averages, slowest worker, and byte totals
- Only adds proto fields does not remove anything.