### PR TITLE
CED-2158: Plumb delta checkpointing through API

### DIFF
--- a/cedana-gpu/gpu/controller.proto
+++ b/cedana-gpu/gpu/controller.proto
@@ -36,10 +36,13 @@ message DumpReq {
   string Dir = 1;
   bool Stream = 2;
   bool LeaveRunning = 3;
+  optional bool Delta = 4; // per-dump override of CEDANA_GPU_DELTA_ENABLED; unset = env default
 }
 
 message DumpResp {
   GpuProfile Profile = 1;
+  bool Delta = 2; // whether this dump was written as a delta
+  string ParentDir = 3; // checkpoint dir this dump chained to; empty if full/base
 }
 
 message RestoreReq {

--- a/cedana/daemon/daemon.proto
+++ b/cedana/daemon/daemon.proto
@@ -97,12 +97,15 @@ message DumpReq {
   string GPUFreezeType = 8; // type of GPU freeze to use, e.g., IPC, NCCL
   DumpAction Action = 9; // action to perform: dump, freeze only, unfreeze only
   bool Async = 10; // whether to perform the dump asynchronously
+  string AsyncDir = 11; // where to stage dump when performing asynchronously
+  optional bool GPUDelta = 12; // GPU delta (incremental) dump; unset = controller env default
 }
 
 message DumpResp {
   repeated string Messages = 1; // messages from the dump
   repeated string Paths = 2; // path to the dump file(s)
   ProcessState State = 3; // state of the process(es) during the dump
+  string GPUParent = 4; // name of the parent checkpoint if the GPU dump was a delta
 }
 
 ////////////////////////


### PR DESCRIPTION
[GPU deltas were previously triggered by setting an env var, which doesn't align with how the rest of the system works when adding configuration to take a checkpoint. This changes it to send an incremental dump over RPC.

Related PRs:

- https://github.com/cedana/cedana-gpu/pull/276
- https://github.com/cedana/cedana-propagator/pull/284
- https://github.com/cedana/cedana-ui/pull/161
- https://github.com/cedana/cedana/pull/857